### PR TITLE
Implement Windows packaging workflow with PyInstaller and add PySide6 MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+__pycache__/
+*.pyc
+build/
+dist/
+*.spec

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # openai-actions-demo
+
+## Offline Python Desktop Monitoring Plan
+
+- 規劃文件：`docs/offline-python-desktop-monitoring-plan.md`
+- MVP 啟動程式：`app/main.py`
+- Windows 開發啟動腳本：`scripts/run_dev.ps1`
+- Windows 打包腳本：`scripts/build_windows.ps1`
+
+## 完成 Windows 打包（PyInstaller）
+
+1. 在 Windows PowerShell 進入專案根目錄。
+2. 執行：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\build_windows.ps1
+```
+
+3. 產物會在：
+
+```text
+dist/offline-monitor/offline-monitor.exe
+```
+
+> `build_windows.ps1` 會自動建立 `.venv`、安裝 `requirements.txt`，再呼叫 PyInstaller 打包。

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,81 @@
+"""Offline desktop monitor launcher UI (MVP stub)."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+
+from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import (
+    QApplication,
+    QLabel,
+    QMainWindow,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class MainWindow(QMainWindow):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Offline Monitor (MVP)")
+        self.resize(640, 420)
+
+        self.status_label = QLabel("狀態：待機")
+        self.log_view = QTextEdit()
+        self.log_view.setReadOnly(True)
+
+        self.start_btn = QPushButton("開始監控")
+        self.stop_btn = QPushButton("停止監控")
+        self.stop_btn.setEnabled(False)
+
+        self.start_btn.clicked.connect(self.start_monitoring)
+        self.stop_btn.clicked.connect(self.stop_monitoring)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.status_label)
+        layout.addWidget(self.start_btn)
+        layout.addWidget(self.stop_btn)
+        layout.addWidget(self.log_view)
+
+        container = QWidget()
+        container.setLayout(layout)
+        self.setCentralWidget(container)
+
+        self.heartbeat_timer = QTimer(self)
+        self.heartbeat_timer.setInterval(5000)
+        self.heartbeat_timer.timeout.connect(self.write_heartbeat)
+
+    def start_monitoring(self) -> None:
+        self.status_label.setText("狀態：監控中")
+        self.start_btn.setEnabled(False)
+        self.stop_btn.setEnabled(True)
+        self.log("Monitoring started.")
+        self.heartbeat_timer.start()
+
+    def stop_monitoring(self) -> None:
+        self.status_label.setText("狀態：已停止")
+        self.start_btn.setEnabled(True)
+        self.stop_btn.setEnabled(False)
+        self.log("Monitoring stopped.")
+        self.heartbeat_timer.stop()
+
+    def write_heartbeat(self) -> None:
+        self.log("Heartbeat OK (stub).")
+
+    def log(self, message: str) -> None:
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self.log_view.append(f"[{now}] {message}")
+
+
+def main() -> int:
+    app = QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    return app.exec()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/offline-python-desktop-monitoring-plan.md
+++ b/docs/offline-python-desktop-monitoring-plan.md
@@ -1,0 +1,194 @@
+# 完全離線 Python 桌面監控系統實作計畫（Windows）
+
+## 1) 需求與範圍
+
+### 需求
+- 24 小時螢幕畫面監控。
+- 即時影像判斷（本地模型或規則）。
+- 自動建立 log（至少包含時間與檔名）。
+- 可在 Windows 直接運行。
+- 不使用任何網路 API（全離線）。
+
+### 非目標（初期）
+- 雲端同步、遠端通知、線上訓練。
+- 跨平台 UI 最佳化（先以 Windows 為主）。
+
+---
+
+## 2) 推薦技術棧
+
+- UI：`PySide6`
+- 螢幕擷取：`mss`
+- 影像處理：`opencv-python`
+- 本地推論：`onnxruntime`（搭配 ONNX 模型）
+- 本地儲存：`sqlite3`（Python 內建）
+- 打包：`PyInstaller`
+
+> 全部可離線部署；模型檔（`.onnx`）與字典檔案均放在本機目錄。
+
+---
+
+## 3) 系統架構
+
+```text
+UI (PySide6)
+  ├─ Monitor Controller
+  │   ├─ Capture Worker (mss)
+  │   ├─ Inference Worker (OpenCV/ONNX Runtime)
+  │   └─ Logger Worker (SQLite + 檔案系統)
+  ├─ Health Monitor (CPU/RAM/Queue)
+  └─ Config Manager (JSON)
+```
+
+### 核心流程
+1. Capture Worker 以固定 FPS 擷取螢幕。
+2. 將影格放入佇列（Queue）。
+3. Inference Worker 做即時判斷。
+4. 事件觸發時輸出截圖檔並寫入 SQLite log。
+5. UI 持續顯示健康狀態與最近事件。
+
+---
+
+## 4) 專案目錄建議
+
+```text
+offline_monitor/
+  app/
+    main.py
+    ui/
+      main_window.py
+    core/
+      capture.py
+      inference.py
+      logger.py
+      retention.py
+      health.py
+    config/
+      default.json
+    models/
+      detector.onnx
+    storage/
+      app.db
+      captures/
+  scripts/
+    run_dev.ps1
+    build_windows.ps1
+  requirements.txt
+  README.md
+```
+
+---
+
+## 5) Log 與資料規格
+
+### SQLite 表（`events`）
+- `id` INTEGER PRIMARY KEY
+- `timestamp` TEXT NOT NULL
+- `event_type` TEXT NOT NULL
+- `confidence` REAL
+- `file_name` TEXT NOT NULL
+- `screen_id` INTEGER
+- `region` TEXT
+- `extra_json` TEXT
+
+### 檔名格式
+- `cap_YYYYMMDD_HHMMSS_mmm.jpg`
+
+### 文字 log（選配）
+- `2026-02-07 14:23:05.421, ALERT_WINDOW, 0.91, cap_20260207_142305_421.jpg`
+
+---
+
+## 6) 24 小時穩定運行設計
+
+- 以固定 FPS（例如 5~15）運行，避免 CPU 爆滿。
+- Capture 與 Inference 解耦（Producer/Consumer Queue）。
+- Queue 設上限，超過時丟棄最舊影格避免積壓。
+- Worker 心跳（每 30~60 秒）寫入健康資訊。
+- 例外處理與自動重啟 worker。
+- 每日輪替資料夾與容量保護（例如上限 50GB）。
+- 開機自啟（Windows 工作排程器或啟動資料夾）。
+
+---
+
+## 7) 開發里程碑
+
+### Milestone A：MVP（1 週）
+- UI 啟停
+- 螢幕擷取 + 截圖落地
+- SQLite log 寫入
+
+**驗收**：連跑 2 小時，無崩潰。
+
+### Milestone B：即時判斷（第 2 週）
+- OpenCV 規則型判斷（模板匹配/區域偵測）
+- 事件觸發與 confidence 記錄
+
+**驗收**：目標 FPS 穩定、誤報率可接受。
+
+### Milestone C：AI 推論（第 3 週）
+- 接 ONNX Runtime + 本地模型
+- 可在 UI 調整閾值
+
+**驗收**：推論延遲與準確率達標。
+
+### Milestone D：部署（第 4 週）
+- PyInstaller 打包
+- 安裝與運維文件
+
+**驗收**：Windows 無 Python 環境可直接執行。
+
+---
+
+## 8) 安全與合規建議
+
+- 明確告知使用者正在監控（UI 狀態與托盤圖示）。
+- 依資料治理要求設定保留天數（例如 7/30 天）。
+- 敏感畫面可做遮罩（PII 區域）。
+- log 與截圖路徑需權限控管。
+
+---
+
+## 9) 風險與對策
+
+- **效能不足**：降低 FPS、改用 ROI、調整模型大小。
+- **磁碟爆滿**：啟用容量上限與自動清理。
+- **誤報偏高**：增加後處理（連續 N 幀才觸發）。
+- **UI 卡頓**：所有重任務放背景執行緒。
+
+---
+
+## 10) 下一步（可直接執行）
+
+1. 先實作 MVP：`capture + sqlite log + ui start/stop`。
+2. 加入最小事件判斷（例如模板匹配）。
+3. 壓測 24 小時並記錄 CPU/RAM/磁碟變化。
+4. 最後接 ONNX 模型並完成 Windows 打包。
+
+
+---
+
+## 11) Windows 打包落地（已提供腳本）
+
+本專案已提供可直接使用的 PowerShell 腳本：
+
+- `scripts/build_windows.ps1`：建立虛擬環境、安裝依賴、執行 PyInstaller。
+- `scripts/run_dev.ps1`：本機開發啟動。
+
+### 一鍵打包
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\build_windows.ps1
+```
+
+### 打包輸出
+
+```text
+dist/offline-monitor/offline-monitor.exe
+```
+
+### 常見注意事項
+
+- 若 PowerShell 執行策略限制，請使用 `-ExecutionPolicy Bypass`。
+- 若缺少 VC++ Runtime，請在目標機安裝 Microsoft Visual C++ Redistributable。
+- 首次安裝依賴較慢屬正常。

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+PySide6==6.8.1
+mss==10.0.0
+opencv-python==4.11.0.86
+onnxruntime==1.20.1
+pyinstaller==6.11.1

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -1,0 +1,21 @@
+param(
+  [string]$Python = "python",
+  [string]$ExeName = "offline-monitor"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path ".venv")) {
+  & $Python -m venv .venv
+}
+
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+
+if (Test-Path "build") { Remove-Item -Recurse -Force "build" }
+if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
+
+pyinstaller --noconfirm --clean --windowed --name $ExeName app/main.py
+
+Write-Host "Build complete: dist/$ExeName/$ExeName.exe"

--- a/scripts/run_dev.ps1
+++ b/scripts/run_dev.ps1
@@ -1,0 +1,14 @@
+param(
+  [string]$Python = "python"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path ".venv")) {
+  & $Python -m venv .venv
+}
+
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+python app/main.py


### PR DESCRIPTION
### Motivation
- Provide concrete artifacts to turn the planning document into a runnable Windows build and close the gap between design and deliverable. 
- Enable reproducible Windows packaging using PyInstaller and give a simple desktop UI entrypoint for manual testing and packaging.

### Description
- Add a PySide6 MVP launcher at `app/main.py` with start/stop controls and a heartbeat log to serve as a packaging target. 
- Add `requirements.txt` with pinned dependencies including `PySide6`, `mss`, `opencv-python`, `onnxruntime`, and `pyinstaller`. 
- Add PowerShell helper scripts `scripts/run_dev.ps1` (dev run) and `scripts/build_windows.ps1` (creates `.venv`, installs deps, runs `pyinstaller`) to enable one-command Windows packaging. 
- Update `README.md` and `docs/offline-python-desktop-monitoring-plan.md` to document the packaging command and output path `dist/offline-monitor/offline-monitor.exe`. 
- Add `.gitignore` entries to exclude `.venv`, build artifacts, and Python bytecode.

### Testing
- Ran `python -m py_compile app/main.py` which completed successfully and validated the Python syntax. 
- Performed static validation of the PowerShell scripts and documented usage because `pwsh` is not available in the Linux CI environment, so the scripts could not be executed here. 
- Repository verification (`git status`/commit) completed successfully after adding the files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986d46002548331a2ece1bd15a3a812)